### PR TITLE
Eeprom write and network programming

### DIFF
--- a/arduinobootloader/arduinobootloader.py
+++ b/arduinobootloader/arduinobootloader.py
@@ -701,7 +701,7 @@ class ArduinoBootloader(object):
             :return: True when success.
             :rtype: bool
             """
-            msg = bytearray([0xFA,0xFE,0x00])
+            msg = bytearray(3)
             if self._send_command(CMD_LEAVE_PROGMODE_ISP, msg):
                 return self._recv_answer(CMD_LEAVE_PROGMODE_ISP)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 pyserial>=3.4
+IntelHex>=2.3
+progressbar>=2.5


### PR DESCRIPTION
This patch add two new features:
1) Write/read the EEPROM section as well as the flash section
2) Use a network socket instead of a serial device. (Just add the net: prefix before the IP instead of the serial device name).